### PR TITLE
EsaのAPIを呼び出すクライアントのラッパークラスを追加

### DIFF
--- a/lib/wataridori.rb
+++ b/lib/wataridori.rb
@@ -2,6 +2,7 @@
 
 require 'wataridori/version'
 require 'wataridori/client'
+require 'wataridori/esa/client'
 
 module Wataridori
   class Error < StandardError; end

--- a/lib/wataridori/client.rb
+++ b/lib/wataridori/client.rb
@@ -8,8 +8,8 @@ module Wataridori
     end
 
     def self.from_teamname(token:, from:, to:)
-      new(from_client: Esa::Client.new(access_token: token, current_team: from),
-          to_client: Esa::Client.new(access_token: token, current_team: to))
+      new(from_client: Wataridori::Esa::Client.new(access_token: token, current_team: from),
+          to_client: Wataridori::Esa::Client.new(access_token: token, current_team: to))
     end
 
     def bulk_copy(category, per_page: 3)

--- a/lib/wataridori/esa/client.rb
+++ b/lib/wataridori/esa/client.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Wataridori
+  module Esa
+    # Esa::Clientのwrapper
+    # リトライやリクエストレートの制御などを行う
+    class Client
+      def initialize(access_token:, current_team:)
+        @original = ::Esa::Client.new(access_token: access_token, current_team: current_team)
+      end
+
+      def method_missing(method_name, *args)
+        if @original.respond_to?(method_name)
+          @original.send(method_name, *args)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name)
+        @original.respond_to?(method_name)
+      end
+    end
+  end
+end

--- a/spec/wataridori/esa/client_spec.rb
+++ b/spec/wataridori/esa/client_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'esa'
+
+RSpec.describe Wataridori::Esa::Client do
+  let(:client) { ::Esa::Client.new(access_token: 'dummy_token', current_team: 'dummy_team') }
+
+  subject do
+    allow(::Esa::Client).to receive(:new).and_return(client)
+    described_class.new(access_token: 'dummy_token', current_team: 'dummy_team')
+  end
+
+  describe 'method_missing' do
+    context 'オリジナルのEsa::Clientに存在するメソッド' do
+      it 'オリジナルを呼び出す' do
+        expect(client).to receive(:posts).and_return('dummy_posts')
+        expect(subject.posts).to eq('dummy_posts')
+      end
+    end
+
+    context 'オリジナルのEsa::Clientに存在しないメソッド' do
+      it 'NoMethodErrorになる' do
+        expect { subject.unexist_method }.to raise_error(NoMethodError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
このあとレート制御やリトライ制御などで、ラップしておいたほうが便利