### PR TITLE
bulk_copyでコピー元/先記事の情報を返すようにする

### DIFF
--- a/lib/wataridori.rb
+++ b/lib/wataridori.rb
@@ -2,6 +2,7 @@
 
 require 'wataridori/version'
 require 'wataridori/client'
+require 'wataridori/copy_result'
 require 'wataridori/esa/client'
 require 'wataridori/esa/ratelimit'
 require 'wataridori/esa/response'

--- a/lib/wataridori/client.rb
+++ b/lib/wataridori/client.rb
@@ -39,8 +39,7 @@ module Wataridori
       created_post = to_client.create_post(post.merge('user' => post.created_by.screen_name))
       logger.info("  post created(from #{post.url} to #{created_post.url})")
       bulk_copy_comments(post.comments, created_post.number)
-      { from: { number: post.number, url: post.url },
-        to: { number: created_post.number, url: created_post.url } }
+      CopyResult.create_by_posts(post, created_post)
     end
 
     def bulk_copy_comments(comments, post_number)

--- a/lib/wataridori/copy_result.rb
+++ b/lib/wataridori/copy_result.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'hashie'
+
+module Wataridori
+  CopyResult = Struct.new(:from, :to) do
+    PostSummary = Struct.new(:number, :url) do
+      def self.by_post(post)
+        new(post.number, post.url)
+      end
+
+      def self.by_hash(hash)
+        new(hash[:number], hash[:url])
+      end
+    end
+
+    def self.create_by_posts(from, to)
+      new(PostSummary.by_post(from), PostSummary.by_post(to))
+    end
+
+    def self.create_by_hash(from:, to:)
+      new(PostSummary.by_hash(from), PostSummary.by_hash(to))
+    end
+
+    def to_h
+      { from: from.to_h, to: to.to_h }
+    end
+  end
+end

--- a/spec/wataridori/client_spec.rb
+++ b/spec/wataridori/client_spec.rb
@@ -21,6 +21,19 @@ RSpec.describe Wataridori::Client do
       'url' => 'https://from.esa.io/1#comment-4' }
   end
 
+  let(:expected) do
+    [
+      Wataridori::CopyResult.create_by_hash(
+        from: { number: 1, url: 'https://from.esa.io/1' },
+        to: { number: 10, url: 'https://to.esa.io/10' }
+      ),
+      Wataridori::CopyResult.create_by_hash(
+        from: { number: 2, url: 'https://from.esa.io/2' },
+        to: { number: 20, url: 'https://to.esa.io/20' }
+      )
+    ]
+  end
+
   subject { described_class.new(from_client: from_client, to_client: to_client, logger: Logger.new('/dev/null')) }
 
   describe '#bulk_copy' do
@@ -49,11 +62,7 @@ RSpec.describe Wataridori::Client do
                 include: 'comments', order: 'asc', sort: 'created')
           .and_return(Wataridori::Esa::Response.new('posts' => [post1, post2]))
 
-        expect(subject.bulk_copy('path/to/category', per_page: 10))
-          .to eq([
-            { from: { number: 1, url: 'https://from.esa.io/1'}, to: {number: 10, url: 'https://to.esa.io/10'} },
-            { from: { number: 2, url: 'https://from.esa.io/2'}, to: {number: 20, url: 'https://to.esa.io/20'} }
-          ])
+        expect(subject.bulk_copy('path/to/category', per_page: 10)).to eq(expected)
       end
     end
 
@@ -69,11 +78,7 @@ RSpec.describe Wataridori::Client do
                 include: 'comments', order: 'asc', sort: 'created')
           .and_return(Wataridori::Esa::Response.new('posts' => [post2]))
 
-        expect(subject.bulk_copy('path/to/category', per_page: 1))
-          .to eq([
-            { from: { number: 1, url: 'https://from.esa.io/1'}, to: {number: 10, url: 'https://to.esa.io/10'} },
-            { from: { number: 2, url: 'https://from.esa.io/2'}, to: {number: 20, url: 'https://to.esa.io/20'} }
-          ])
+        expect(subject.bulk_copy('path/to/category', per_page: 1)).to eq(expected)
       end
     end
   end


### PR DESCRIPTION
resolve #19

URLの置き換えに備えて、 `bulk_copy`でコピーした記事の情報を返すようにする。
とりあえずnumber, urlさえあればいいかなと思って実装した。
実行結果をそのまま別メソッドに渡すなり、to_hした結果をファイルに吐き出すなり、どちらでもいけるはず。