### PR TITLE
Set required keywords

### DIFF
--- a/bin/wataridori
+++ b/bin/wataridori
@@ -41,7 +41,7 @@ when 'bulk_copy'
   YAML.dump(copy_results.map(&:to_h), File.open(path, 'w')) if path
 when 'replace_links'
   copy_results = ARGV.slice(1..-1).inject([]) do |results, filepath|
-    results + YAML.load_file(filepath).map { |h| Wataridori::CopyResult.create_by_hash(from: h[:from], to: h[:to])  }
+    results + YAML.load_file(filepath).map { |h| Wataridori::CopyResult.create_by_hash(from: h[:from], to: h[:to]) }
   end
   usage if copy_results.length.zero?
 

--- a/bin/wataridori
+++ b/bin/wataridori
@@ -41,7 +41,7 @@ when 'bulk_copy'
   YAML.dump(copy_results.map(&:to_h), File.open(path, 'w')) if path
 when 'replace_links'
   copy_results = ARGV.slice(1..-1).inject([]) do |results, filepath|
-    results + YAML.load_file(filepath).map { |h| Wataridori::CopyResult.create_by_hash(h) }
+    results + YAML.load_file(filepath).map { |h| Wataridori::CopyResult.create_by_hash(from: h[:from], to: h[:to])  }
   end
   usage if copy_results.length.zero?
 


### PR DESCRIPTION
replace_links を実行する際に、required keywords が指定されていないために下記のエラーが出ましたので、修正しました。

```
/home/scnsh/wataridori/lib/wataridori/copy_result.rb:21:in `create_by_hash': wrong number of arguments (given 1, expected 0; required keywords: from, to) (ArgumentError)
        from bin/wataridori:45:in `block (2 levels) in <main>'
        from bin/wataridori:45:in `map'
        from bin/wataridori:45:in `block in <main>'
        from bin/wataridori:43:in `each'
        from bin/wataridori:43:in `inject'
        from bin/wataridori:43:in `<main>'
```